### PR TITLE
Fix de-duplication bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ nytprof.out
 *.bs
 /_eumm/
 *~
+MultiTestDB.conf
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: "perl"
 
+services:
+  - mysql
+
 perl:
   - "5.26"
   - "5.14"
@@ -23,9 +26,9 @@ before_install:
 
 
 install:
-    - cpanm -n Devel::Cover::Report::Coveralls
-    - cpanm -n DBD::SQLite
-    - cpanm -n JSON
+    - cpanm --sudo -n Devel::Cover::Report::Coveralls
+    - cpanm --sudo -n DBD::SQLite
+    - cpanm --sudo -n JSON
     - cp travisci/MultiTestDB.conf.travisci.mysql  modules/t/MultiTestDB.conf.mysql
     - cp travisci/MultiTestDB.conf.travisci.SQLite modules/t/MultiTestDB.conf.SQLite
     - cd ensembl && cpanm -v --installdeps .

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
     - cpanm --sudo -n JSON
     - cp travisci/MultiTestDB.conf.travisci.mysql  modules/t/MultiTestDB.conf.mysql
     - cp travisci/MultiTestDB.conf.travisci.SQLite modules/t/MultiTestDB.conf.SQLite
-    - cd ensembl && cpanm -v --installdeps .
+    - cd ensembl && cpanm --sudo --installdeps .
     - cd -
 
 script: "./travisci/harness.sh"


### PR DESCRIPTION
The presence of duplicate names was tested with a 'fetchrow_array' statement; if it returned a true value, 'fetchall_arrayref' was used to iterate over the duplicates. But... that first fetchrow_array popped the first duplicate off the stack, but never processed it. So we were always left with a single duplicate in the finished database. Changed the logic to process all duplicates, and added a final check, to verify that our de-duplication code worked.