### PR TITLE
Improve output of POD

### DIFF
--- a/modules/Bio/EnsEMBL/Taxonomy/DBSQL/TaxonomyDBAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Taxonomy/DBSQL/TaxonomyDBAdaptor.pm
@@ -1,3 +1,4 @@
+=encoding utf8
 
 =head1 LICENSE
 
@@ -15,8 +16,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-=cut
-
 =head1 CONTACT
 
   Please email comments or questions to the public Ensembl
@@ -24,8 +23,6 @@ limitations under the License.
 
   Questions may also be sent to the Ensembl help desk at
   <helpdesk@ensembl.org>.
-
-=cut
 
 =head1 NAME
 
@@ -37,19 +34,19 @@ Specialised DBAdaptor for connecting to the ncbi_taxonomy MySQL database
 
 =head1 SYNOPSIS
 
-#create an adaptor (Registry cannot be used currently)
-my $tax_dba =  Bio::EnsEMBL::Taxonomy::DBSQL::TaxonomyDBAdaptor->new(
-									  -user   => $tax_user,
-									  -pass   => $tax_pass,
-									  -dbname => $tax_db,
-									  -host   => $tax_host,
-									  -port   => $tax_port);	
-my $node_adaptor = $tax_dba->get_TaxonomyNodeAdaptor();
+  #create an adaptor (Registry cannot be used currently)
+  my $tax_dba =  Bio::EnsEMBL::Taxonomy::DBSQL::TaxonomyDBAdaptor->new(
+    -user   => $tax_user,
+    -pass   => $tax_pass,
+    -dbname => $tax_db,
+    -host   => $tax_host,
+    -port   => $tax_port);
+  my $node_adaptor = $tax_dba->get_TaxonomyNodeAdaptor();
 									  
-=head DESCRIPTION
+=head1 DESCRIPTION
 
 A specialised DBAdaptor allowing connection to an ncbi_taxonomy database. 
-Can be used to retrieve an instance of Bio::EnsEMBL::DBSQL::TaxonomyAdaptor.
+Can be used to retrieve an instance of C<Bio::EnsEMBL::DBSQL::TaxonomyAdaptor>.
 
 =head1 AUTHOR
 
@@ -78,11 +75,19 @@ use Bio::EnsEMBL::Taxonomy::DBSQL::TaxonomyNodeAdaptor;
 
 	Description	: Retrieve all adaptors supported by this database
 	Returns		: Hash of adaptor modules by name
+
 =cut
 
 sub get_available_adaptors {
   return {'TaxonomyNode' => 'Bio::EnsEMBL::Taxonomy::DBSQL::TaxonomyNodeAdaptor'};
 }
+
+=head2 get_TaxonomyNodeAdaptor
+
+	Description	: Retrieve a C<Bio::EnsEMBL::Taxonomy::DBSQL::TaxonomyNodeAdaptor>
+	Returns		: A C<Bio::EnsEMBL::Taxonomy::DBSQL::TaxonomyNodeAdaptor> instance
+
+=cut
 
 sub get_TaxonomyNodeAdaptor {
 	my ($self) = @_;
@@ -90,4 +95,3 @@ sub get_TaxonomyNodeAdaptor {
 }
 
 1;
-

--- a/modules/Bio/EnsEMBL/Taxonomy/DBSQL/TaxonomyNodeAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Taxonomy/DBSQL/TaxonomyNodeAdaptor.pm
@@ -33,73 +33,80 @@ Bio::EnsEMBL::Taxonomy::DBSQL::TaxonomyNodeAdaptor
 
 =head1 SYNOPSIS
 
-#create an adaptor (Registry cannot be used currently)
-my $tax_dba =  Bio::EnsEMBL::Taxonomy::DBSQL::TaxonomyDBAdaptor->new(
-									  -user   => $tax_user,
-									  -pass   => $tax_pass,
-									  -dbname => $tax_db,
-									  -host   => $tax_host,
-									  -port   => $tax_port);									  
-my $node_adaptor = $tax_dba->get_TaxonomyNodeAdaptor();
-# get a node for an ID
-my $node = $node_adaptor->fetch_by_taxon_id(511145);
-# print some info
-printf "Node %d is %s %s\n",$node->taxon_id(),$node->rank(),$node->names()->{'scientific name'}->[0];
-# Finding ancestors
-my @lineage = @{$node_adaptor->fetch_ancestors($node)};
-for my $node (@lineage) {
-    printf "Node %d is %s %s\n",$node->taxon_id(),$node->rank(),$node->names()->{'scientific name'}->[0];
-}
+  #create an adaptor (Registry cannot be used currently)
+  my $tax_dba =  Bio::EnsEMBL::Taxonomy::DBSQL::TaxonomyDBAdaptor->new(
+    -user   => $tax_user,
+    -pass   => $tax_pass,
+    -dbname => $tax_db,
+    -host   => $tax_host,
+    -port   => $tax_port);
+  my $node_adaptor = $tax_dba->get_TaxonomyNodeAdaptor();
+  # get a node for an ID
+  my $node = $node_adaptor->fetch_by_taxon_id(511145);
+  # print some info
+  printf "Node %d is %s %s\n", $node->taxon_id(), $node->rank(), $node->names()->{'scientific name'}->[0];
+  # Finding ancestors
+  my @lineage = @{$node_adaptor->fetch_ancestors($node)};
+  for my $node (@lineage) {
+    printf "Node %d is %s %s\n", $node->taxon_id(), $node->rank(), $node->names()->{'scientific name'}->[0];
+  }
 
 =head1 DESCRIPTION
 
 A database adaptor allowing access to the nodes of the NCBI taxonomy. It is currently managed independently of the registry:
-my $tax_dba =  Bio::EnsEMBL::Taxonomy::DBSQL::TaxonomyDBAdaptor->new(
-									  -user   => $tax_user,
-									  -pass   => $tax_pass,
-									  -dbname => $tax_db,
-									  -host   => $tax_host,
-									  -port   => $tax_port);
+
+  my $tax_dba =  Bio::EnsEMBL::Taxonomy::DBSQL::TaxonomyDBAdaptor->new(
+    -user   => $tax_user,
+    -pass   => $tax_pass,
+    -dbname => $tax_db,
+    -host   => $tax_host,
+    -port   => $tax_port);
 									  									  
-my $node_adaptor = $tax_dba->get_TaxonomyNodeAdaptor();
-# or alternatively
-my $node_adaptor = Bio::EnsEMBL::Taxonomy::DBSQL::TaxonomyNodeAdaptor->new($tax_dba);
+  my $node_adaptor = $tax_dba->get_TaxonomyNodeAdaptor();
+  # or alternatively
+  my $node_adaptor = Bio::EnsEMBL::Taxonomy::DBSQL::TaxonomyNodeAdaptor->new($tax_dba);
 
 The TaxonomyNodeAdaptor handles TaxonomyNode objects, which represent nodes in the NCBI taxonomy
 
 There are two main practical uses for the :
-1. Accessing the taxonomy database to find species of interest and to then find those within the Ensembl databases e.g. to find all 
-descendants of the node representing Escherichia coli:
-	my $node = $node_adaptor->fetch_by_taxon_id(562);
-	for my $child (@{$node_adaptor->fetch_descendants($node)}) {
-		my $dbas = $helper->get_all_by_taxon_id($node->taxon_id())
-		if(defined $dbas) {
-			for my $dba (@{$dbas}) {
-				# do something with the $dba
-			}
-		}
-	}
 
-2. Placing species into a taxonomic hierarchy and manipulating that hierarchy (mainly for use in the web interface)
-	# iterate over all dbas from a registry or LookUp
-	for my $dba (@{$helper->get_all_DBAdaptors()}) {
-		my $node = $node_adaptor->fetch_by_coredbadaptor($dba);
-		# add the node to a hash set of leaf nodes if not already there
-		if ( $leaf_nodes->{ $node->taxon_id() } ) {
-			$node = $leaf_nodes->{ $node->taxon_id() };
-		} else {
-			$leaf_nodes->{ $node->taxon_id() } = $node;
-		}
-		# attach the DBA to the node
-		push @{$node->dba()}, $dba;
-	}
-	my @leaf_nodes = values(%$leaf_nodes);
-	# get the root of the tree
-	my $root = $node_adaptor->fetch_by_taxon_id(1);
-	# get rid of all branches of the taxonomy that don't involve a node from the dba
-	$node_adaptor->build_pruned_tree( $root, \@leaf_nodes );
-	# collapse 
-	$node_adaptor->collapse_tree($root);
+=over 2
+
+=item 1. Accessing the taxonomy database to find species of interest and to then find those within the Ensembl databases e.g. to find all descendants of the node representing Escherichia coli:
+
+  my $node = $node_adaptor->fetch_by_taxon_id(562);
+  for my $child (@{$node_adaptor->fetch_descendants($node)}) {
+    my $dbas = $helper->get_all_by_taxon_id($node->taxon_id());
+    if(defined $dbas) {
+      for my $dba (@{$dbas}) {
+        # do something with the $dba
+      }
+    }
+  }
+
+=item 2. Placing species into a taxonomic hierarchy and manipulating that hierarchy (mainly for use in the web interface)
+
+  # iterate over all dbas from a registry or LookUp
+  for my $dba (@{$helper->get_all_DBAdaptors()}) {
+    my $node = $node_adaptor->fetch_by_coredbadaptor($dba);
+    # add the node to a hash set of leaf nodes if not already there
+    if ( $leaf_nodes->{ $node->taxon_id() } ) {
+      $node = $leaf_nodes->{ $node->taxon_id() };
+    } else {
+      $leaf_nodes->{ $node->taxon_id() } = $node;
+    }
+    # attach the DBA to the node
+    push @{$node->dba()}, $dba;
+  }
+  my @leaf_nodes = values(%$leaf_nodes);
+  # get the root of the tree
+  my $root = $node_adaptor->fetch_by_taxon_id(1);
+  # get rid of all branches of the taxonomy that don't involve a node from the dba
+  $node_adaptor->build_pruned_tree( $root, \@leaf_nodes );
+  # collapse 
+  $node_adaptor->collapse_tree($root);
+
+=back
 	
 =head1 AUTHOR
 
@@ -175,9 +182,9 @@ q{select n.taxon_id, n.parent_id, n.rank, n.root_id, n.left_index, n.right_index
 
 =head2 fetch_by_coredbadaptor
 
-Description : Fetch a single node corresponding to the taxonomy ID found in the supplied Ensembl DBAdaptor. Warning: Passing 2 different DBAs with the same taxid will yield two distinct Node objects which will need merging! COnsider using fetch_by_coredbadaptors instead.
-Argument    : Bio::EnsEMBL::DBSQL::DBAdaptor
-Return type : Bio::EnsEMBL::Taxonomy::TaxonomyNode
+  Description : Fetch a single node corresponding to the taxonomy ID found in the supplied Ensembl DBAdaptor. Warning: Passing 2 different DBAs with the same taxid will yield two distinct Node objects which will need merging! COnsider using fetch_by_coredbadaptors instead.
+  Argument    : Bio::EnsEMBL::DBSQL::DBAdaptor
+  Return type : Bio::EnsEMBL::Taxonomy::TaxonomyNode
 =cut
 
 sub fetch_by_coredbadaptor {
@@ -197,9 +204,9 @@ sub fetch_by_coredbadaptor {
 
 =head2 fetch_by_coredbadaptors
 
-Description : Fetch an array of nodes corresponding to the taxonomy IDs found in the supplied Ensembl DBAdaptors.
-Argument    : Bio::EnsEMBL::DBSQL::DBAdaptor
-Return type : Arrayref of Bio::EnsEMBL::Taxonomy::TaxonomyNode
+  Description : Fetch an array of nodes corresponding to the taxonomy IDs found in the supplied Ensembl DBAdaptors.
+  Argument    : Bio::EnsEMBL::DBSQL::DBAdaptor
+  Return type : Arrayref of Bio::EnsEMBL::Taxonomy::TaxonomyNode
 =cut
 
 sub fetch_by_coredbadaptors {
@@ -232,9 +239,9 @@ sub fetch_by_coredbadaptors {
 
 =head2 fetch_by_taxon_id
 
-Description : Fetch a single node corresponding to the supplied taxon ID.
-Argument    : Int
-Return type : Bio::EnsEMBL::Taxonomy::TaxonomyNode
+  Description : Fetch a single node corresponding to the supplied taxon ID.
+  Argument    : Int
+  Return type : Bio::EnsEMBL::Taxonomy::TaxonomyNode
 =cut
 
 sub fetch_by_taxon_id {
@@ -246,11 +253,12 @@ sub fetch_by_taxon_id {
 							 -PARAMS   => [$taxon_id]);
   return $node->{$taxon_id};
 }
+
 =head2 fetch_by_taxon_name
 
-Description : Fetch a single node where the name is as specified
-Argument    : String
-Return type : Bio::EnsEMBL::Taxonomy::TaxonomyNode
+  Description : Fetch a single node where the name is as specified
+  Argument    : String
+  Return type : Bio::EnsEMBL::Taxonomy::TaxonomyNode
 =cut
 
 sub fetch_by_taxon_name {
@@ -263,11 +271,12 @@ q{ join ncbi_taxa_name nan using (taxon_id) where nan.name=?},
 							 -PARAMS   => [$name]);
   return _first_element([values(%$node)]);
 }
+
 =head2 fetch_all_by_taxon_ids
 
-Description : Fetch an array of nodes corresponding to the supplied taxonomy IDs
-Argument    : Arrayref of Int
-Return type : Arrayref of Bio::EnsEMBL::Taxonomy::TaxonomyNode
+  Description : Fetch an array of nodes corresponding to the supplied taxonomy IDs
+  Argument    : Arrayref of Int
+  Return type : Arrayref of Bio::EnsEMBL::Taxonomy::TaxonomyNode
 =cut
 
 sub fetch_all_by_taxon_ids {
@@ -282,9 +291,9 @@ sub fetch_all_by_taxon_ids {
 
 =head2 fetch_all_by_rank
 
-Description : Fetch an array of nodes which have the supplied rank
-Argument    : String
-Return type : Arrayref of Bio::EnsEMBL::Taxonomy::TaxonomyNode
+  Description : Fetch an array of nodes which have the supplied rank
+  Argument    : String
+  Return type : Arrayref of Bio::EnsEMBL::Taxonomy::TaxonomyNode
 =cut
 
 sub fetch_all_by_rank {
@@ -299,9 +308,9 @@ sub fetch_all_by_rank {
 
 =head2 fetch_all_by_name
 
-Description : Fetch an array of nodes which have a name LIKE the supplied String
-Argument    : Name as String (can contain SQL wildcards)
-Return type : Arrayref of Bio::EnsEMBL::Taxonomy::TaxonomyNode
+  Description : Fetch an array of nodes which have a name LIKE the supplied String
+  Argument    : Name as String (can contain SQL wildcards)
+  Return type : Arrayref of Bio::EnsEMBL::Taxonomy::TaxonomyNode
 =cut
 
 sub fetch_all_by_name {
@@ -317,10 +326,10 @@ q{ join ncbi_taxa_name nan using (taxon_id) where nan.name like ?},
 
 =head2 fetch_by_name_and_class
 
-Description : Fetch a node which has a name and name class LIKE the supplied Strings
-Argument    : Name as String (can contain SQL wildcards)
-Argument    : Name class as String (can contain SQL wildcards)
-Return type : Bio::EnsEMBL::Taxonomy::TaxonomyNode
+  Description : Fetch a node which has a name and name class LIKE the supplied Strings
+  Argument    : Name as String (can contain SQL wildcards)
+  Argument    : Name class as String (can contain SQL wildcards)
+  Return type : Bio::EnsEMBL::Taxonomy::TaxonomyNode
 =cut
 
 sub fetch_by_name_and_class {
@@ -333,10 +342,10 @@ sub fetch_by_name_and_class {
 
 =head2 fetch_all_by_name_and_class
 
-Description : Fetch an array of nodes which have a name and name class LIKE the supplied Strings
-Argument    : Name as String (can contain SQL wildcards)
-Argument    : Name class as String (can contain SQL wildcards)
-Return type : Arrayref of Bio::EnsEMBL::Taxonomy::TaxonomyNode
+  Description : Fetch an array of nodes which have a name and name class LIKE the supplied Strings
+  Argument    : Name as String (can contain SQL wildcards)
+  Argument    : Name class as String (can contain SQL wildcards)
+  Return type : Arrayref of Bio::EnsEMBL::Taxonomy::TaxonomyNode
 =cut
 
 sub fetch_all_by_name_and_class {
@@ -352,10 +361,10 @@ q{ join ncbi_taxa_name nan using (taxon_id) where nan.name like ? and nan.name_c
 
 =head2 fetch_all_by_name_and_rank
 
-Description : Fetch an array of nodes which have the supplied rank and a name LIKE the supplied String
-Argument    : Name as String (can contain SQL wildcards)
-Argument    : Rank as String
-Return type : Arrayref of Bio::EnsEMBL::Taxonomy::TaxonomyNode
+  Description : Fetch an array of nodes which have the supplied rank and a name LIKE the supplied String
+  Argument    : Name as String (can contain SQL wildcards)
+  Argument    : Rank as String
+  Return type : Arrayref of Bio::EnsEMBL::Taxonomy::TaxonomyNode
 =cut
 
 sub fetch_all_by_name_and_rank {
@@ -371,9 +380,9 @@ q{ join ncbi_taxa_name nan using (taxon_id) where nan.name like ? and n.rank = ?
 
 =head2 fetch_parent
  
-Description : Fetch a single node corresponding to the parent of the node
-Argument    : Bio::EnsEMBL::Taxonomy::TaxonomyNode or ID of desired node
-Return type : Bio::EnsEMBL::Taxonomy::TaxonomyNode
+  Description : Fetch a single node corresponding to the parent of the node
+  Argument    : Bio::EnsEMBL::Taxonomy::TaxonomyNode or ID of desired node
+  Return type : Bio::EnsEMBL::Taxonomy::TaxonomyNode
 =cut
 
 sub fetch_parent {
@@ -389,9 +398,9 @@ sub fetch_parent {
 
 =head2 fetch_root
 
-Description : Fetch a single node corresponding to the root of the supplied node
-Argument    : Bio::EnsEMBL::Taxonomy::TaxonomyNode or ID of desired node
-Return type : Bio::EnsEMBL::Taxonomy::TaxonomyNode
+  Description : Fetch a single node corresponding to the root of the supplied node
+  Argument    : Bio::EnsEMBL::Taxonomy::TaxonomyNode or ID of desired node
+  Return type : Bio::EnsEMBL::Taxonomy::TaxonomyNode
 =cut
 
 sub fetch_root {
@@ -407,9 +416,9 @@ sub fetch_root {
 
 =head2 fetch_children
 
-Description : Fetch an array of nodes for which the parent is the supplied node
-Argument    : Bio::EnsEMBL::Taxonomy::TaxonomyNode or ID of desired node
-Return type : Arrayref of Bio::EnsEMBL::Taxonomy::TaxonomyNode
+  Description : Fetch an array of nodes for which the parent is the supplied node
+  Argument    : Bio::EnsEMBL::Taxonomy::TaxonomyNode or ID of desired node
+  Return type : Arrayref of Bio::EnsEMBL::Taxonomy::TaxonomyNode
 =cut
 
 sub fetch_children {
@@ -484,10 +493,11 @@ sub _get_node_id {
 
 =head2 fetch_descendants
 
-Description : Fetch an array of nodes below the supplied node on the tree
-Argument    : Bio::EnsEMBL::Taxonomy::TaxonomyNode or ID of desired node
-Return type : Arrayref of Bio::EnsEMBL::Taxonomy::TaxonomyNode
+  Description : Fetch an array of nodes below the supplied node on the tree
+  Argument    : Bio::EnsEMBL::Taxonomy::TaxonomyNode or ID of desired node
+  Return type : Arrayref of Bio::EnsEMBL::Taxonomy::TaxonomyNode
 =cut
+
 sub fetch_descendants {
   my ($self, $node) = @_;
   my $sql = $base_sql . q{ join ncbi_taxa_node parent 
@@ -503,10 +513,11 @@ sub fetch_descendants {
 
 =head2 fetch_descendant_ids
 
-Description : Fetch an array of taxon IDs below the supplied node on the tree
-Argument    : Bio::EnsEMBL::Taxonomy::TaxonomyNode or ID of desired node
-Return type : Arrayref of integers
+  Description : Fetch an array of taxon IDs below the supplied node on the tree
+  Argument    : Bio::EnsEMBL::Taxonomy::TaxonomyNode or ID of desired node
+  Return type : Arrayref of integers
 =cut
+
 sub fetch_descendant_ids {
   my ($self, $node) = @_;
   my $sql = q/select n.taxon_id from ncbi_taxa_node n join ncbi_taxa_node parent 
@@ -519,9 +530,9 @@ sub fetch_descendant_ids {
 
 =head2 fetch_leaf_nodes
 
-Description : Fetch an array of nodes which are the leaves below the supplied node on the tree
-Argument    : Bio::EnsEMBL::Taxonomy::TaxonomyNode or ID of desired node
-Return type : Arrayref of Bio::EnsEMBL::Taxonomy::TaxonomyNode
+  Description : Fetch an array of nodes which are the leaves below the supplied node on the tree
+  Argument    : Bio::EnsEMBL::Taxonomy::TaxonomyNode or ID of desired node
+  Return type : Arrayref of Bio::EnsEMBL::Taxonomy::TaxonomyNode
 =cut
 
 sub fetch_leaf_nodes {
@@ -537,9 +548,9 @@ sub fetch_leaf_nodes {
 
 =head2 fetch_ancestors
 
-Description : Fetch an array of nodes which are above the supplied node on the tree (ordered ascending up the tree)
-Argument    : Bio::EnsEMBL::Taxonomy::TaxonomyNode or ID of desired node
-Return type : Arrayref of Bio::EnsEMBL::Taxonomy::TaxonomyNode
+  Description : Fetch an array of nodes which are above the supplied node on the tree (ordered ascending up the tree)
+  Argument    : Bio::EnsEMBL::Taxonomy::TaxonomyNode or ID of desired node
+  Return type : Arrayref of Bio::EnsEMBL::Taxonomy::TaxonomyNode
 =cut
 
 sub fetch_ancestors {
@@ -556,10 +567,10 @@ sub fetch_ancestors {
 
 =head2 node_has_ancestor
 
-Description : Find if one node has another as an ancestor
-Argument    : Bio::EnsEMBL::Taxonomy::TaxonomyNode or ID of desired node
-Argument    : Bio::EnsEMBL::Taxonomy::TaxonomyNode or ID of ancestor
-Return type : 1 if ancestor 
+  Description : Find if one node has another as an ancestor
+  Argument    : Bio::EnsEMBL::Taxonomy::TaxonomyNode or ID of desired node
+  Argument    : Bio::EnsEMBL::Taxonomy::TaxonomyNode or ID of ancestor
+  Return type : 1 if ancestor 
 =cut
 
 sub node_has_ancestor {
@@ -574,10 +585,10 @@ sub node_has_ancestor {
 
 =head2 fetch_descendants_offset
 
-Description : Fetch an array of nodes below the node the specified number of levels on the tree above the specified node
-Argument    : Bio::EnsEMBL::Taxonomy::TaxonomyNode or ID of desired node
-Argument    : offset (number of rows to move up tree before getting descendants - default is 1)
-Return type : Arrayref of Bio::EnsEMBL::Taxonomy::TaxonomyNode
+  Description : Fetch an array of nodes below the node the specified number of levels on the tree above the specified node
+  Argument    : Bio::EnsEMBL::Taxonomy::TaxonomyNode or ID of desired node
+  Argument    : offset (number of rows to move up tree before getting descendants - default is 1)
+  Return type : Arrayref of Bio::EnsEMBL::Taxonomy::TaxonomyNode
 =cut
 
 sub fetch_descendants_offset {
@@ -593,9 +604,9 @@ sub fetch_descendants_offset {
 
 =head2 add_descendants
 
-Description : Fetch descendants for the supplied node and assemble into a tree
-Argument    : Bio::EnsEMBL::Taxonomy::TaxonomyNode
-Return type : None
+  Description : Fetch descendants for the supplied node and assemble into a tree
+  Argument    : Bio::EnsEMBL::Taxonomy::TaxonomyNode
+  Return type : None
 =cut
 
 sub add_descendants {
@@ -607,9 +618,9 @@ sub add_descendants {
 
 =head2 associate_nodes
 
-Description : Associate the supplied nodes into a tree based on left/right indices and return the root node
-Argument    : Arrayref of Bio::EnsEMBL::Taxonomy::TaxonomyNode
-Return type : Bio::EnsEMBL::Taxonomy::TaxonomyNode
+  Description : Associate the supplied nodes into a tree based on left/right indices and return the root node
+  Argument    : Arrayref of Bio::EnsEMBL::Taxonomy::TaxonomyNode
+  Return type : Bio::EnsEMBL::Taxonomy::TaxonomyNode
 =cut
 
 sub associate_nodes {
@@ -642,9 +653,9 @@ sub associate_nodes {
 
 =head2 set_num_descendants
 
-Description : Traverse the supplied tree setting number of descendants based on current tree structure
-Argument    : Bio::EnsEMBL::Taxonomy::TaxonomyNode
-Return type : None
+  Description : Traverse the supplied tree setting number of descendants based on current tree structure
+  Argument    : Bio::EnsEMBL::Taxonomy::TaxonomyNode
+  Return type : None
 =cut
 
 sub set_num_descendants {
@@ -657,10 +668,11 @@ sub set_num_descendants {
 }
 
 =head2 _get_parent_by_index
-Description: Find the parent of a node, initially based on left/right index to find direct parent, and then by recursion through parents to work back to the closest common ancestor.
-Argument: Current node
-Argument: Prospective parent
-Return type: Bio::EnsEMBL::Taxonomy::TaxonomyNode
+
+  Description: Find the parent of a node, initially based on left/right index to find direct parent, and then by recursion through parents to work back to the closest common ancestor.
+  Argument: Current node
+  Argument: Prospective parent
+  Return type: Bio::EnsEMBL::Taxonomy::TaxonomyNode
 =cut
 
 sub _get_parent_by_index {
@@ -678,10 +690,11 @@ sub _get_parent_by_index {
 }
 
 =head2 build_pruned_tree
-Description : Restrict supplied tree by list of key leaf nodes
-Argument    : Bio::EnsEMBL::Taxonomy::TaxonomyNode
-Argument    : Array ref of Bio::EnsEMBL::Taxonomy::TaxonomyNode
-Return type : None
+
+  Description : Restrict supplied tree by list of key leaf nodes
+  Argument    : Bio::EnsEMBL::Taxonomy::TaxonomyNode
+  Argument    : Array ref of Bio::EnsEMBL::Taxonomy::TaxonomyNode
+  Return type : None
 =cut
 
 sub build_pruned_tree {
@@ -696,11 +709,12 @@ sub build_pruned_tree {
 }
 
 =head2 collapse_tree
-Description : Remove all nodes from tree that do not fit the required criteria. By default, these are not branch points, the root node, leaf nodes or nodes with database adaptors.
-Argument    : Bio::EnsEMBL::Taxonomy::TaxonomyNode
-Argument    : Array ref of Bio::EnsEMBL::Taxonomy::TaxonomyNode
-Argument    : (Optional) Subroutine reference which is used to define whether to retain a node
-Return type : None
+
+  Description : Remove all nodes from tree that do not fit the required criteria. By default, these are not branch points, the root node, leaf nodes or nodes with database adaptors.
+  Argument    : Bio::EnsEMBL::Taxonomy::TaxonomyNode
+  Argument    : Array ref of Bio::EnsEMBL::Taxonomy::TaxonomyNode
+  Argument    : (Optional) Subroutine reference which is used to define whether to retain a node
+  Return type : None
 =cut
 
 sub collapse_tree {
@@ -726,10 +740,11 @@ sub collapse_tree {
 }
 
 =head2 distance_between_nodes
-Description : Count the number of steps in the shortest route from one node to another (via the common ancestor)
-Argument    : Bio::EnsEMBL::Taxonomy::TaxonomyNode
-Argument    : Bio::EnsEMBL::Taxonomy::TaxonomyNode
-Return type : Integer
+
+  Description : Count the number of steps in the shortest route from one node to another (via the common ancestor)
+  Argument    : Bio::EnsEMBL::Taxonomy::TaxonomyNode
+  Argument    : Bio::EnsEMBL::Taxonomy::TaxonomyNode
+  Return type : Integer
 =cut
 
 sub distance_between_nodes {
@@ -754,9 +769,10 @@ sub distance_between_nodes {
 }
 
 =head2 _build_node_array
-Description: Build a sparse array based on left/right indices of a set of nodes to allow speedy lookup
-Argument: Arrayref of Bio::EnsEMBL::Taxonomy::TaxonomyNode
-Return type: Arrayref containing arrayref of 1/0 by left/right, min left index, max right index
+
+  Description: Build a sparse array based on left/right indices of a set of nodes to allow speedy lookup
+  Argument: Arrayref of Bio::EnsEMBL::Taxonomy::TaxonomyNode
+  Return type: Arrayref containing arrayref of 1/0 by left/right, min left index, max right index
 =cut
 
 sub _build_node_array {
@@ -782,10 +798,11 @@ sub _build_node_array {
 }
 
 =head2 _restrict_set
-Description: Restrict the input set to those needed to build a tree including all members of the leaf set
-Argument: Arrayref of Bio::EnsEMBL::Taxonomy::TaxonomyNode (leaf set)
-Argument: Arrayref of Bio::EnsEMBL::Taxonomy::TaxonomyNode (input set)
-Return: Arrayref of Bio::EnsEMBL::Taxonomy::TaxonomyNode
+
+  Description: Restrict the input set to those needed to build a tree including all members of the leaf set
+  Argument: Arrayref of Bio::EnsEMBL::Taxonomy::TaxonomyNode (leaf set)
+  Argument: Arrayref of Bio::EnsEMBL::Taxonomy::TaxonomyNode (input set)
+  Return: Arrayref of Bio::EnsEMBL::Taxonomy::TaxonomyNode
 =cut
 
 sub _restrict_set {
@@ -822,6 +839,7 @@ sub _restrict_set {
 } ## end sub _restrict_set
 
 =head2 _first_element
+
   Arg	     : arrayref
   Description: Utility method to return the first element in a list, undef if empty
   Returntype : arrayref element
@@ -841,4 +859,3 @@ sub _first_element {
 }
 
 1;
-

--- a/modules/Bio/EnsEMBL/Taxonomy/TaxonomyNode.pm
+++ b/modules/Bio/EnsEMBL/Taxonomy/TaxonomyNode.pm
@@ -1,3 +1,5 @@
+=encoding utf8
+
 =head1 LICENSE
 
 Copyright [2009-2019] EMBL-European Bioinformatics Institute
@@ -14,10 +16,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-=cut
-
-=pod
-
 =head1 CONTACT
 
   Please email comments or questions to the public Ensembl
@@ -25,10 +23,6 @@ limitations under the License.
 
   Questions may also be sent to the Ensembl help desk at
   <helpdesk@ensembl.org>.
- 
-__END__
-
-=pod
 
 =head1 NAME
 
@@ -36,14 +30,14 @@ Bio::EnsEMBL::Taxonomy::TaxonomyNode
 
 =head1 SYNOPSIS
 
-my $node = $node_adaptor->fetch_by_taxon_id(511145);
-# print some info
-printf "Node %d is %s %s\n",$node->taxon_id(),$node->rank(),$node->names()->{'scientific name'}->[0];
-# Finding ancestors
-my @lineage = @{$node_adaptor->fetch_ancestors($node)};
-for my $node (@lineage) {
+  my $node = $node_adaptor->fetch_by_taxon_id(511145);
+  # print some info
+  printf "Node %d is %s %s\n",$node->taxon_id(),$node->rank(),$node->names()->{'scientific name'}->[0];
+  # Finding ancestors
+  my @lineage = @{$node_adaptor->fetch_ancestors($node)};
+  for my $node (@lineage) {
     printf "Node %d is %s %s\n",$node->taxon_id(),$node->rank(),$node->names()->{'scientific name'}->[0];
-}
+  }
 
 =head1 DESCRIPTION
 
@@ -130,39 +124,47 @@ sub new {
 
 =head2 taxon_id
 
-Description : Taxon ID of this node
-Return type : Int
+  Description : Taxon ID of this node
+  Return type : Int
+
 =cut
 
 sub taxon_id {
   my ($self) = @_;
   return $self->{'taxon_id'};
 }
+
 =head2 parent_id
 
-Taxon ID of the parent of this node
-Return type : Int
+  Taxon ID of the parent of this node
+  Return type : Int
+
 =cut
 
 sub parent_id {
   my ($self) = @_;
   return $self->{'parent_id'};
 }
+
 =head2 root_id
 
-Description : Taxon ID of the root node for the taxonomy.
-Return type : Int
+  Description : Taxon ID of the root node for the taxonomy.
+  Return type : Int
+
 =cut
 
 sub root_id {
   my ($self) = @_;
   return $self->{'root_id'};
 }
+
 =head2 names 
 
-Description : Hashref of names for this node. Hash keys are the class of name, and values are arrays of names (as you can have more than one name for each class)
-Return type : hashref
+  Description : Hashref of names for this node. Hash keys are the class of name, and values are arrays of names (as you can have more than one name for each class)
+  Return type : hashref
+
 =cut
+
 sub names {
   my ($self) = @_;
   return $self->{'names'};
@@ -173,19 +175,24 @@ sub name {
   $name_class ||= 'scientific name';
   return $self->names()->{$name_class}->[0];
 }
+
 =head2 rank
 
-Description : Taxonomic rank
-Return type : String
+  Description : Taxonomic rank
+  Return type : String
+
 =cut
+
 sub rank {
   my ($self) = @_;
   return $self->{'rank'};
 }
+
 =head2 num_descendants
 
-Description : Total number of descendants in the tree
-Return type : Int
+  Description : Total number of descendants in the tree
+  Return type : Int
+
 =cut
 
 sub num_descendants {
@@ -196,9 +203,10 @@ sub num_descendants {
 
 =head2 dba
 
-Description : Getter/setter for core database adaptor for this node
-Argument    : (optional) Bio::EnsEMBL::Taxonomy::DBSQL::TaxonomyNodeAdaptor
-Return type : Bio::EnsEMBL::Taxonomy::DBSQL::TaxonomyNodeAdaptor
+  Description : Getter/setter for core database adaptor for this node
+  Argument    : (optional) Bio::EnsEMBL::Taxonomy::DBSQL::TaxonomyNodeAdaptor
+  Return type : Bio::EnsEMBL::Taxonomy::DBSQL::TaxonomyNodeAdaptor
+
 =cut
 
 sub dba {
@@ -211,10 +219,12 @@ sub dba {
 
 =head2 root
 
-Description	  : Getter/setter for root node for this node (fetched lazily using adaptor)
-Argument    : (optional) Bio::EnsEMBL::Taxonomy::TaxonomyNode
-Return type   : Bio::EnsEMBL::Taxonomy::TaxonomyNode
+  Description	  : Getter/setter for root node for this node (fetched lazily using adaptor)
+  Argument    : (optional) Bio::EnsEMBL::Taxonomy::TaxonomyNode
+  Return type   : Bio::EnsEMBL::Taxonomy::TaxonomyNode
+
 =cut
+
 sub root {
   my ($self, $arg) = @_;
   if (defined $arg) {
@@ -228,9 +238,10 @@ sub root {
 
 =head2 parent
 
-Description	  : Getter/setter for parent node for this node (fetched lazily using adaptor)
-Argument      : (optional) Bio::EnsEMBL::Taxonomy::TaxonomyNode
-Return type   : Bio::EnsEMBL::Taxonomy::TaxonomyNode
+  Description	  : Getter/setter for parent node for this node (fetched lazily using adaptor)
+  Argument      : (optional) Bio::EnsEMBL::Taxonomy::TaxonomyNode
+  Return type   : Bio::EnsEMBL::Taxonomy::TaxonomyNode
+
 =cut
 
 sub parent {
@@ -246,9 +257,10 @@ sub parent {
 
 =head2 children
 
-Description	  : Getter/setter for arrayref of child nodes for this node (fetched lazily using adaptor)
-Argument      : (optional) Arrayref of Bio::EnsEMBL::Taxonomy::TaxonomyNode
-Return type   : Arrayref of Bio::EnsEMBL::Taxonomy::TaxonomyNode
+  Description	  : Getter/setter for arrayref of child nodes for this node (fetched lazily using adaptor)
+  Argument      : (optional) Arrayref of Bio::EnsEMBL::Taxonomy::TaxonomyNode
+  Return type   : Arrayref of Bio::EnsEMBL::Taxonomy::TaxonomyNode
+
 =cut
 
 sub children {
@@ -264,8 +276,9 @@ sub children {
 
 =head2 is_root
 
-Description		: Returns 1 if this is a root node with no parents
-Return type     : Int
+  Description		: Returns 1 if this is a root node with no parents
+  Return type     : Int
+
 =cut
 
 sub is_root {
@@ -275,8 +288,9 @@ sub is_root {
 
 =head2 is_leaf
 
-Description		: Returns 1 if this is a leaf node with no children
-Return type     : Int
+  Description		: Returns 1 if this is a leaf node with no children
+  Return type     : Int
+
 =cut
 
 sub is_leaf {
@@ -286,8 +300,9 @@ sub is_leaf {
 
 =head2 is_branch
 
-Description		: Returns 1 if this is a branch node with more than one direct child
-Return type     : Int
+  Description		: Returns 1 if this is a branch node with more than one direct child
+  Return type     : Int
+
 =cut
 
 sub is_branch {
@@ -298,9 +313,11 @@ sub is_branch {
   return $self->{is_branch};
 }
 
-=head2 add_all_descendants 
-Description		: Uses database to fetch all descendants for this node from database and assemble them into a tree
-Return type     : None
+=head2 add_all_descendants
+ 
+  Description		: Uses database to fetch all descendants for this node from database and assemble them into a tree
+  Return type     : None
+
 =cut
 
 sub add_all_descendants {
@@ -309,10 +326,12 @@ sub add_all_descendants {
   return;
 }
 
-=head2 add_child 
-Description		: Add child node (if not already present)
-Argument        : Arrayref of Bio::EnsEMBL::Taxonomy::TaxonomyNode
-Return type     : None
+=head2 add_child
+
+  Description		: Add child node (if not already present)
+  Argument        : Arrayref of Bio::EnsEMBL::Taxonomy::TaxonomyNode
+  Return type     : None
+
 =cut
 
 sub add_child {
@@ -324,8 +343,10 @@ sub add_child {
 }
 
 =head2 traverse_tree
-Description 	: Walk the tree recursively, invoking the supplied subroutine on each node
-Argument 		: Subroutine reference, accepting current node and depth
+
+  Description 	: Walk the tree recursively, invoking the supplied subroutine on each node
+  Argument 		: Subroutine reference, accepting current node and depth
+
 =cut
 
 sub traverse_tree {
@@ -339,9 +360,11 @@ sub traverse_tree {
 }
 
 =head2 count_leaves  
-Description		: Counts all leaf or DBA nodes below this node
-Argument        : (Optional) closure checking whether to count a node or not
-Return type     : Int
+
+  Description		: Counts all leaf or DBA nodes below this node
+  Argument        : (Optional) closure checking whether to count a node or not
+  Return type     : Int
+
 =cut 
 
 sub count_leaves {
@@ -361,9 +384,11 @@ sub count_leaves {
 }
 
 =head2 distance_to_node
-Description 	: Calculate the distance between this and the supplied node in steps via the closest common ancestor
-Argument 		: Bio::EnsEMBL::Taxonomy::TaxonomyNode
-Return type		: Int
+
+  Description 	: Calculate the distance between this and the supplied node in steps via the closest common ancestor
+  Argument 		: Bio::EnsEMBL::Taxonomy::TaxonomyNode
+  Return type		: Int
+
 =cut
 
 sub distance_to_node {
@@ -372,9 +397,11 @@ sub distance_to_node {
 }
 
 =head2 has_ancestor
-Description : Test if the ancestors of this node include the supplied node
-Argument : Putative ancestor
-Return: 1 if the supplied node is an ancestor of this node
+
+  Description : Test if the ancestors of this node include the supplied node
+  Argument : Putative ancestor
+  Return: 1 if the supplied node is an ancestor of this node
+
 =cut
 
 sub has_ancestor {
@@ -383,8 +410,10 @@ sub has_ancestor {
 }
 
 =head2 to_string
-Description : Return simple string representation of node
-Argument : (Optional) name_class to display (default is 'scientific name')
+
+  Description : Return simple string representation of node
+  Argument : (Optional) name_class to display (default is 'scientific name')
+
 =cut
 
 sub to_string {
@@ -394,7 +423,9 @@ sub to_string {
 }
 
 =head2 to_tree_string
-Description: Render tree as a string
+
+  Description: Render tree as a string
+
 =cut
 
 sub to_tree_string {
@@ -411,4 +442,3 @@ sub to_tree_string {
 
 
 1;
-


### PR DESCRIPTION
This pull request only has changes to the POD of the modules. It aims to improve the output from `perldoc`. One such example is from:
```
SYNOPSIS
    my $node = $node_adaptor->fetch_by_taxon_id(511145); # print some info
    printf "Node %d is %s
    %s\n",$node->taxon_id(),$node->rank(),$node->names()->{'scientific
    name'}->[0]; # Finding ancestors my @lineage =
    @{$node_adaptor->fetch_ancestors($node)}; for my $node (@lineage) {
    printf "Node %d is %s
    %s\n",$node->taxon_id(),$node->rank(),$node->names()->{'scientific
    name'}->[0]; }
```

to:
```
SYNOPSIS
      my $node = $node_adaptor->fetch_by_taxon_id(511145);
      # print some info
      printf "Node %d is %s %s\n",$node->taxon_id(),$node->rank(),$node->names()->{'scientific name'}->[0];
      # Finding ancestors
      my @lineage = @{$node_adaptor->fetch_ancestors($node)};
      for my $node (@lineage) {
        printf "Node %d is %s %s\n",$node->taxon_id(),$node->rank(),$node->names()->{'scientific name'}->[0];
      }
```

Also `annual_copyright_updater.sh` needs running.