### PR TITLE
Fix database config for tests

### DIFF
--- a/modules/t/20-family.t
+++ b/modules/t/20-family.t
@@ -20,25 +20,23 @@ use Test::More;
 use Bio::EnsEMBL::Taxonomy::TaxonomyNode;
 use Bio::EnsEMBL::Taxonomy::DBSQL::TaxonomyDBAdaptor;
 use Bio::EnsEMBL::Taxonomy::DBSQL::TaxonomyNodeAdaptor;
+use Bio::EnsEMBL::Test::MultiTestDB;
 
 use FindBin qw($Bin);
-my $conf_file = "$Bin/db.conf";
 
+my $conf_file = "$Bin/db.conf";
 my $conf = do $conf_file
   || die "Could not load configuration from " . $conf_file;
 
 $conf = $conf->{tax_test};
 
-my $dba =  Bio::EnsEMBL::DBSQL::DBAdaptor->new(
-									  -user   => $conf->{user},
-									  -pass   => $conf->{pass},
-									  -dbname => $conf->{db},
-									  -host   => $conf->{host},
-									  -port   => $conf->{port},
-									  -driver => $conf->{driver});
-									  
+my $test_db_dir = $FindBin::Bin;
+my $testdb  = Bio::EnsEMBL::Test::MultiTestDB->new('multi', $test_db_dir);
+
+my $dba = $testdb->get_DBAdaptor('taxonomy');
+
 my $node_adaptor = Bio::EnsEMBL::Taxonomy::DBSQL::TaxonomyNodeAdaptor->new($dba);
-		
+
 ok( defined $node_adaptor, 'Checking if the node adaptor is defined' );
 
 my $node = $node_adaptor->fetch_by_taxon_id( $conf->{taxon_id} )

--- a/modules/t/41-find_common_ancestor.t
+++ b/modules/t/41-find_common_ancestor.t
@@ -19,21 +19,20 @@ use Test::More;
 use Bio::EnsEMBL::Taxonomy::TaxonomyNode;
 use Bio::EnsEMBL::Taxonomy::DBSQL::TaxonomyDBAdaptor;
 use Bio::EnsEMBL::Taxonomy::DBSQL::TaxonomyNodeAdaptor;
+use Bio::EnsEMBL::Test::MultiTestDB;
 
 use FindBin qw($Bin);
-my $conf_file = "$Bin/db.conf";
 
+my $conf_file = "$Bin/db.conf";
 my $conf = do $conf_file
   || die "Could not load configuration from " . $conf_file;
 
 $conf = $conf->{tax_test};
-my $dba =  Bio::EnsEMBL::DBSQL::DBAdaptor->new(
-									  -user   => $conf->{user},
-									  -pass   => $conf->{pass},
-									  -dbname => $conf->{db},
-									  -host   => $conf->{host},
-									  -port   => $conf->{port},
-									  -driver => $conf->{driver});
+
+my $test_db_dir = $FindBin::Bin;
+my $testdb  = Bio::EnsEMBL::Test::MultiTestDB->new('multi', $test_db_dir);
+
+my $dba = $testdb->get_DBAdaptor('taxonomy');
 									  
 my $node_adaptor = Bio::EnsEMBL::Taxonomy::DBSQL::TaxonomyNodeAdaptor->new($dba);
 		

--- a/modules/t/43-has_ancestor.t
+++ b/modules/t/43-has_ancestor.t
@@ -19,21 +19,20 @@ use Test::More;
 use Bio::EnsEMBL::Taxonomy::TaxonomyNode;
 use Bio::EnsEMBL::Taxonomy::DBSQL::TaxonomyDBAdaptor;
 use Bio::EnsEMBL::Taxonomy::DBSQL::TaxonomyNodeAdaptor;
+use Bio::EnsEMBL::Test::MultiTestDB;
 
 use FindBin qw($Bin);
-my $conf_file = "$Bin/db.conf";
 
+my $conf_file = "$Bin/db.conf";
 my $conf = do $conf_file
   || die "Could not load configuration from " . $conf_file;
 
 $conf = $conf->{tax_test};
-my $dba =  Bio::EnsEMBL::DBSQL::DBAdaptor->new(
-									  -user   => $conf->{user},
-									  -pass   => $conf->{pass},
-									  -dbname => $conf->{db},
-									  -host   => $conf->{host},
-									  -port   => $conf->{port},
-									  -driver => $conf->{driver});
+
+my $test_db_dir = $FindBin::Bin;
+my $testdb  = Bio::EnsEMBL::Test::MultiTestDB->new('multi', $test_db_dir);
+
+my $dba = $testdb->get_DBAdaptor('taxonomy');
 									  
 my $node_adaptor = Bio::EnsEMBL::Taxonomy::DBSQL::TaxonomyNodeAdaptor->new($dba);
 		

--- a/modules/t/db.conf
+++ b/modules/t/db.conf
@@ -1,20 +1,14 @@
 {
 	tax_test=>{
- 	 	port   => '4157',
-  	 	driver => 'mysql',
- 	 	user   => 'anonymous',
-  		pass   => '',
-  		host     => 'mysql-eg-publicsql.ebi.ac.uk',
-  		db     => 'test_ncbi_taxonomy',
   		taxon_id => '8',
   		name => 'Escherichia coli%',
   		rank => 'species',
   		name_class => 'scientific name'
 	},
 	tax=>{
- 	 	port   => '4157',
+ 	 	  port   => '4157',
   	 	driver => 'mysql',
- 	 	user   => 'anonymous',
+ 	 	  user   => 'anonymous',
   		pass   => '',
   		host   => 'mysql-eg-publicsql.ebi.ac.uk',
   		db     => 'ncbi_taxonomy',


### PR DESCRIPTION
Fix database config for tests, so that a test database is created rather than trying to connect to a non-existent test db on the public SQL server.