### PR TITLE
flag to trigger copy job

### DIFF
--- a/modules/Bio/EnsEMBL/Taxonomy/PipeConfig/ImportNCBItaxonomy_conf.pm
+++ b/modules/Bio/EnsEMBL/Taxonomy/PipeConfig/ImportNCBItaxonomy_conf.pm
@@ -57,6 +57,7 @@ sub default_options {
     src_host         => undef,
     tgt_host         => undef,
     tgt_db_name      => undef,
+    copy_to_tgt_host => 0,
     payload          =>
       '{'.
         '"src_host": "'.$self->o('pipeline_db', '-host').':'.$self->o('pipeline_db', '-port').'", '.
@@ -225,8 +226,9 @@ sub pipeline_analyses {
       -module     => 'Bio::EnsEMBL::Taxonomy::RunnableDB::PostLoadChecks',
       -parameters => {
                        tgt_host => $self->o('tgt_host'),
+                       copy_to_tgt_host => $self->o('copy_to_tgt_host'),
                      },
-      -flow_into  => { 1 => WHEN('defined #tgt_host#' => [ 'copy_database' ]), },
+      -flow_into  => { 1 => WHEN('defined #tgt_host# && #copy_to_tgt_host#' => [ 'copy_database' ]), },
     },
     {
       -logic_name => 'copy_database',


### PR DESCRIPTION
Taxonomy pipeline used by another teams doesn't require copy step when tag_host param is declared.
New flag copy_to_tgt_host added to prevent the copy unless user explicitly specifies that copy step required.
More details : ENSPROD-7467